### PR TITLE
Non-permanent rerouting

### DIFF
--- a/inc/controllers/controller.php
+++ b/inc/controllers/controller.php
@@ -46,4 +46,15 @@ class Controller extends \F3instance
         $this->tpserve();
     }
 
+    /**
+     * Reroute to specified URI
+     * @param string $uri
+     * @param bool $permanent
+     */
+    function reroute($uri,$permanent=FALSE) {
+        if (!$permanent)
+            $_SERVER['REQUEST_METHOD']='POST';//dirty hack to force a 303 redirection
+        parent::reroute($uri);
+    }
+
 }


### PR DESCRIPTION
This fixes #2 + a related issue (project selector) on browsers that cache 301 redirects.
